### PR TITLE
compress jpg pictures

### DIFF
--- a/config_apps/nemo-scripts-plugins/reduceJpgQuality70pc.sh
+++ b/config_apps/nemo-scripts-plugins/reduceJpgQuality70pc.sh
@@ -1,0 +1,15 @@
+#/!/bin/bash
+
+# Save in Linux Mint Nemo filemanager at  
+# ~/.local/share/nemo/scripts
+
+# Check imagemagick dependancy is installed
+if [$(which convert)=""];then
+    sudo apt install -y imagemagick > /dev/null
+fi
+
+mkdir ./compressed
+
+for f in *.JPG; do convert "$f" -quality 70 compressed/"$f"; done 
+
+for f in *.jpg; do convert "$f" -quality 70 compressed/"$f"; done 


### PR DESCRIPTION
In Nemo click into a directory containing .jpg or .JPG pictures
Clicking on this script will compress the quality of all the images by 70% saving them into a new directory called 'compressed'

Imagemagick should install automatically if not already installed though this hasn't been tested properly yet